### PR TITLE
Svg Addin

### DIFF
--- a/SkiaSharpFiddle/Compiler/AssemblyLoader.cs
+++ b/SkiaSharpFiddle/Compiler/AssemblyLoader.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace SkiaSharpFiddle
+{
+    public class AssemblyLoader
+    {
+        private static readonly string[] WhitelistedAssemblies =
+        {
+            "netstandard",
+            "mscorlib",
+            "System",
+            "System.Core",
+            "System.Private.CoreLib",
+            "System.Runtime",
+            "SkiaSharp",
+            "SkiaSharp.Extended",
+            "SkiaSharp.Extended.Svg",
+            "System.Xml.ReaderWriter",
+            "System.Private.Xml",
+        };
+
+        public AssemblyLoader()
+        {
+            AddExternalAssemblies();
+        }
+
+        public IEnumerable<Assembly> GetReferences() =>
+            AppDomain.CurrentDomain
+                     .GetAssemblies()
+                     .Where(a => WhitelistedAssemblies.Any(wl => wl.Equals(a.GetName().Name, StringComparison.OrdinalIgnoreCase)));
+
+        private void AddExternalAssemblies()
+        {
+            var skiasharpExtendedReference = SkiaSharp.Extended.SKGeometry.PI;
+            var skiasharpSvgReference = new SkiaSharp.Extended.Svg.SKSvg();
+        }
+    }
+}

--- a/SkiaSharpFiddle/MainWindow.xaml
+++ b/SkiaSharpFiddle/MainWindow.xaml
@@ -85,9 +85,9 @@
                           ItemsSource="{Binding ColorCombinations}" DisplayMemberPath="Name" />
                 <Separator />
                 <Label Content="Width: " />
-                <TextBox Text="{Binding DrawingWidth, Mode=TwoWay}" Width="100" />
+                <TextBox Text="{Binding DrawingWidth, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="100" />
                 <Label Content="Height: " />
-                <TextBox Text="{Binding DrawingHeight, Mode=TwoWay}" Width="100" />
+                <TextBox Text="{Binding DrawingHeight, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="100" />
             </ToolBar>
         </ToolBarTray>
 

--- a/SkiaSharpFiddle/SkiaSharpFiddle.csproj
+++ b/SkiaSharpFiddle/SkiaSharpFiddle.csproj
@@ -16,12 +16,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AvalonEdit" Version="6.0.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.4.0" />
+    <PackageReference Include="AvalonEdit" Version="6.0.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.5.0" />
     <PackageReference Include="Refractored.MvvmHelpers" Version="1.4.1-beta" />
-    <PackageReference Include="SkiaSharp" Version="1.68.1" />
-    <PackageReference Include="SkiaSharp.Views.WPF" Version="1.68.1" NoWarn="NU1701" />
-    <PackageReference Include="System.Reactive" Version="4.3.1" />
+    <PackageReference Include="SkiaSharp" Version="1.68.1.1" />
+    <PackageReference Include="SkiaSharp.Views.WPF" Version="1.68.1.1" NoWarn="NU1701" />
+    <PackageReference Include="System.Reactive" Version="4.3.2" />
   </ItemGroup>
 
 </Project>

--- a/SkiaSharpFiddle/SkiaSharpFiddle.csproj
+++ b/SkiaSharpFiddle/SkiaSharpFiddle.csproj
@@ -20,6 +20,8 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.5.0" />
     <PackageReference Include="Refractored.MvvmHelpers" Version="1.4.1-beta" />
     <PackageReference Include="SkiaSharp" Version="1.68.1.1" />
+    <PackageReference Include="SkiaSharp.Extended" Version="1.60.0" />
+    <PackageReference Include="SkiaSharp.Svg" Version="1.60.0" />
     <PackageReference Include="SkiaSharp.Views.WPF" Version="1.68.1.1" NoWarn="NU1701" />
     <PackageReference Include="System.Reactive" Version="4.3.2" />
   </ItemGroup>


### PR DESCRIPTION
Added SkiaSharp.Extended and SkiaSharp.Extended.Svg to SkiaSharpFiddle to enable prototyping with svg images.
An Example can be found here: 
https://gist.github.com/FT-dev/044318b415298e556e3694991ccad3e9

Also changed width and height update to OnPropertyChanged, because when entering the editor, the canvas size does not update properly. It is necessary to click on the top menu bar.

---
*Background to this PR:*  
I personally had to edit a quite complex graphical animation, where this beautiful app helped enormously to be efficient. But I had to update the source code to support SVGs.
 Feel free to change and thanks for the App!